### PR TITLE
fixing repo according to documentation

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -11,8 +11,8 @@
 class logstash::repo {
   $version = $logstash::repo_version
   $repo_name = "elastic-${version}"
-  $url_root = "https://artifacts.elastic.co/packages/${version}"
-  $gpg_key_url = 'https://artifacts.elastic.co/GPG-KEY-elasticsearch'
+  $url_root = "https://packages.elastic.co/elasticsearch/${version}/debian"
+  $gpg_key_url = 'https://packages.elastic.co/GPG-KEY-elasticsearch'
   $gpg_key_id = '46095ACC8548582C1A2699A9D27D666CD88E42B4'
 
   Exec {


### PR DESCRIPTION
Fixing repo URL according to documentation 
https://www.elastic.co/guide/en/elasticsearch/reference/2.4/setup-repositories.html